### PR TITLE
Enforce the removal of filenames to be checked 

### DIFF
--- a/src/main/java/net/jacksum/gui/Main.java
+++ b/src/main/java/net/jacksum/gui/Main.java
@@ -255,6 +255,8 @@ public class Main extends javax.swing.JFrame implements AlgorithmSelectorDialogI
                 // it to null, because we want to control verification mode at the GUI by command line args
                 // (at the file browser integration)
                 parametersFromProps.setCheckFile(null);
+                // make sure that the filenames to be checked are removed from a previous run
+                parametersFromProps.setFilenamesFromCheckFile(null);
                 parametersFromProps.getVerbose().setDefault();
 
                 // parametersFromProps.setParameterModifiedByAPI(true);
@@ -2325,6 +2327,11 @@ public class Main extends javax.swing.JFrame implements AlgorithmSelectorDialogI
 
             // check file
             parameters.setCheckFile(fileVerificationTextField.getText());
+            
+            // make sure that the filenames are removed from a previous run after setting a new verification file
+            // or changing the content of the verification file (without restarting HashGarten)
+            parameters.setFilenamesFromCheckFile(null);
+
             parameters.setCharsetCheckFile(fileVerificationCharacterSetComboBox.getSelectedItem().toString());
             
             customStylePanel2parameters(


### PR DESCRIPTION
Dear Jonela

Thanks a lot for your Jacksum and HashGarten system, I like it a lot. 

Issue to report: I encountered a persistent parameter/property problem when using HashGarten/Jacksum Version 2.9.0 on Windows 11 (Version 24H2, OS Build 26100.4652). 

My Task: I had to check a couple of deliveries mainly with content and md5-verification files that contained relative paths. Please check the following steps-to-reproduce 

# Prerequisite
* Extract the sample-files.zip 
   * jacksum-test01
   * jacksum-test01-nextrun

[sample-files.zip](https://github.com/user-attachments/files/21430577/sample-files.zip)

* Delete .HashGarten.properties to have a clean start

# Part one

1. Directly open HashGarten (not with "Send to")

2. Go to Output Style > Pathstyle: set to "relativize paths to" and give the absolute path of the content folder to be checked.

3. Go to menu Operation Mode > Verify Hash Values

4. Add the content folder to be checked

5. Go to Calculation > Set the algorithm md5

6. Go to Output Style > Check Print header 

7. Go to Output Files, set the output and error file

8. Press the "Verify Hash Values" Button

9. Await the message box "HashGarten task has been finished"

10. Check output: All good

(12. Keep HashGarten opened)

output-01.txt

```
#
# created by: Jacksum (https://jacksum.net, version: 3.7.0)
# invoked on JVM: OpenJDK 64-Bit Server VM (vendor: Eclipse Adoptium, version: 21.0.5+11-LTS)
# invoked on OS: Windows 11 (arch: amd64, version: 10.0)
# invoked on date: 2025-07-25T13:24:13.858+02:00
#
# invoked from: C:\Users\stefan\Jacksum for Windows
# invocation args: -a md5 --header -c C:\Temp\jacksum-test01\checksum.md5 --path-relative-to C:\Temp\jacksum-test01\content --output-file-overwrite c:\temp\output01.txt --error-file-overwrite c:\temp\error01.txt
#__________________________________________________________________________________________________________________________________________________________________________________________________________________
       OK  C:\Temp\jacksum-test01\content\test.pdf
```

error-01.txt
Empty.


# Part two

1. Keep HashGarten opened

2. Rename the sample folder form Part one: jacksum-test01 -> jacksum-test01.removed. Just to make sure that it does not interfere with the next run. 

3. Repeat steps Part One 2 - 09, but with the new sample folder jacksum-test02-nextrun, make sure to fix the relative path, content folder and verification file.

4. Check output: Failure

output-01.txt

```
#
# created by: Jacksum (https://jacksum.net, version: 3.7.0)
# invoked on JVM: OpenJDK 64-Bit Server VM (vendor: Eclipse Adoptium, version: 21.0.5+11-LTS)
# invoked on OS: Windows 11 (arch: amd64, version: 10.0)
# invoked on date: 2025-07-25T13:26:31.946+02:00
#
# invoked from: C:\Users\stefan\Jacksum for Windows
# invocation args: -a md5 --header -c C:\Temp\jacksum-test01-nextrun\checksum.md5 --path-relative-to C:\Temp\jacksum-test01-nextrun\content --output-file-overwrite c:\temp\output01.txt --error-file-overwrite c:\temp\error01.txt
#__________________________________________________________________________________________________________________________________________________________________________________________________________________________________
```

error-01.txt
```
Jacksum: Error: C:\Temp\jacksum-test01\content\test.pdf: does not exist.
```

Note: 

* Even if all new values have been set for the 'nextrun', the error output shows that it still 
refers to a file from the first run. In other words, something is persistent from to another run. 

* I'm not sure whether this happens only when dealing with verification files that use relative paths.

# Suggested Fix

I tried to suggest a fix that is only in the HashGarten project. When testing the changes from this pull request, the procedure above succeeded. Of course I don't know whether this changes have undesired side effects. Probably there is a better location to fix the issue. If the fix is not OK, at least it gives you an idea of what I'm getting at.

Note: I could not test any "Send to" cases coming from a file manager.

Thanks for your attention.

Best Regards
baddonkey